### PR TITLE
Fix unified layouts with left and right enabled

### DIFF
--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -213,13 +213,17 @@ dot (const RV& R, const XMV& X, const YMV& Y,
   }
 
   // Create unmanaged versions of the input Views.
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
 
   typedef Kokkos::View<
     typename Kokkos::Impl::if_c<
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -227,7 +231,7 @@ dot (const RV& R, const XMV& X, const YMV& Y,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
   typedef Kokkos::View<

--- a/src/blas/KokkosBlas1_iamax.hpp
+++ b/src/blas/KokkosBlas1_iamax.hpp
@@ -130,14 +130,19 @@ iamax (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
-  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 2.
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
+  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 1.
   // XMV may be rank 1 or rank 2.
   typedef Kokkos::View<
     typename std::conditional<
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename std::conditional<
       std::is_same<typename RV::device_type::memory_space, Kokkos::HostSpace>::value,
       Kokkos::HostSpace,
@@ -148,7 +153,7 @@ iamax (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_mult.hpp
+++ b/src/blas/KokkosBlas1_mult.hpp
@@ -85,26 +85,24 @@ mult (typename YMV::const_value_type& gamma,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using YUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout;
+  using AUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<AV, YUnifiedLayout>::array_layout;
+  using XUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<XMV, YUnifiedLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      YMV::rank == 1,
-      typename YMV::non_const_value_type*,
-      typename YMV::non_const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
+    typename YMV::non_const_data_type,
+    YUnifiedLayout,
     typename YMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > YMV_Internal;
   typedef Kokkos::View<
     typename AV::const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<AV>::array_layout,
+    AUnifiedLayout,
     typename AV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > AV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    XUnifiedLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -129,6 +129,11 @@ nrm1 (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
@@ -136,7 +141,7 @@ nrm1 (const RV& R, const XMV& X,
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -144,7 +149,7 @@ nrm1 (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2.hpp
+++ b/src/blas/KokkosBlas1_nrm2.hpp
@@ -64,7 +64,7 @@ nrm2 (const XVector& x)
   static_assert (Kokkos::Impl::is_view<XVector>::value,
                  "KokkosBlas::nrm2: XVector must be a Kokkos::View.");
   static_assert (XVector::rank == 1, "KokkosBlas::nrm2: "
-                 "Both Vector inputs must have rank 1.");
+                 "XVector must have rank 1.");
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_value_type>::mag_type mag_type;
 
   typedef Kokkos::View<typename XVector::const_value_type*,
@@ -129,22 +129,21 @@ nrm2 (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2_squared.hpp
@@ -74,7 +74,7 @@ nrm2_squared (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    typename XVector::array_layout,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 
@@ -129,22 +129,21 @@ nrm2_squared (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -129,6 +129,11 @@ nrminf (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
@@ -136,7 +141,7 @@ nrminf (const RV& R, const XMV& X,
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -144,7 +149,7 @@ nrminf (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_scal.hpp
+++ b/src/blas/KokkosBlas1_scal.hpp
@@ -78,27 +78,26 @@ scal (const RMV& R, const AV& a, const XMV& X)
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedRLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout;
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<XMV, UnifiedRLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.  AV may be either a rank-1 View, or a scalar
   // value.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RMV::rank == 1,
-      typename RMV::non_const_value_type*,
-      typename RMV::non_const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout,
+    typename RMV::non_const_data_type,
+    UnifiedRLayout,
     typename RMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RMV_Internal;
-  typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-    AV, XMV, true>::type AV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
+  typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<
+    AV, XMV_Internal, true>::type AV_Internal;
 
   RMV_Internal R_internal = R;
   AV_Internal  a_internal = a;

--- a/src/blas/KokkosBlas1_sum.hpp
+++ b/src/blas/KokkosBlas1_sum.hpp
@@ -122,22 +122,21 @@ sum (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas2_gemv.hpp
+++ b/src/blas/KokkosBlas2_gemv.hpp
@@ -124,19 +124,21 @@ gemv (const char trans[],
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using ALayout = typename AViewType::array_layout;
+
   // Minimize the number of Impl::GEMV instantiations, by
   // standardizing on particular View specializations for its template
   // parameters.
   typedef Kokkos::View<typename AViewType::const_value_type**,
-    typename AViewType::array_layout,
+    ALayout,
     typename AViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > AVT;
   typedef Kokkos::View<typename XViewType::const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XViewType>::array_layout,
+    typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<XViewType, ALayout>::array_layout,
     typename XViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVT;
   typedef Kokkos::View<typename YViewType::non_const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<YViewType>::array_layout,
+    typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<YViewType, ALayout>::array_layout,
     typename YViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVT;
 

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -446,11 +446,11 @@ extern template struct Axpby< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      2, false, true>; \
 extern template struct Axpby< \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -466,11 +466,11 @@ template struct Axpby< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      2, false, true>; \
 template struct Axpby< \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -344,11 +344,11 @@ spmv (KokkosKernels::Experimental::Controls controls,
   // Call single-vector version if appropriate
   if (x.extent(1) == 1) {
     typedef Kokkos::View<typename XVector::const_value_type*,
-      typename YVector::array_layout,
+      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
       typename XVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > XVector_SubInternal;
     typedef Kokkos::View<typename YVector::non_const_value_type*,
-      typename YVector::array_layout,
+      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
       typename YVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVector_SubInternal;
 


### PR DESCRIPTION
Expose "Impl::UnifiedLayoutPreferring" that means "get a layout compatible with this view, but if possible use this other layout". This is just a renaming of UnifiedLayoutInternal. UnifiedLayout is just this, where the preferred layout is ``default_layout``.

Fix SpMV layout for case where Y is LayoutStride but X is not. This is not a common case obviously but in principle we support it.

I tested this on my local machine with 3 eti combinations: LayoutLeft, LayoutRight, and both.